### PR TITLE
Open the detail flyer in new tab

### DIFF
--- a/demo/static/gstudio/img/oe101-plain.svg
+++ b/demo/static/gstudio/img/oe101-plain.svg
@@ -723,7 +723,8 @@
            style="font-size:48px;font-style:normal;font-weight:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Asap;-inkscape-font-specification:Asap">
           <a
              id="a11314"
-             xlink:href="http://nroer.gov.in/CourseOnOERFindOutMore/">
+             xlink:href="http://nroer.gov.in/CourseOnOERFindOutMore/"
+             xlink:show="new">
             <g
                id="g11296">
               <path
@@ -2488,6 +2489,7 @@
       <a
          id="a6691"
          xlink:href="http://nroer.gov.in/CourseOnOERFindOutMore/"
+         xlink:show="new"
          style="fill:none">
         <g
            id="g6686"


### PR DESCRIPTION
The CourseOnOERFindOutMore svg was rendering in a frame instead of on a new page. This change will direct the browser to open the link in a new tab/window.
